### PR TITLE
Random Issue command

### DIFF
--- a/MoMMI/Modules/chance.py
+++ b/MoMMI/Modules/chance.py
@@ -115,7 +115,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
     url = github_url(f"/repos/{repo}/issues", params)
     issues = await get_github_object(url)
 
-    rand_issue = random.choice(issues)
+    rand_issue = random.choice(issues).number
 
     await issue_command(channel, f"[{rand_issue}]", f"[{rand_issue}]")
     #await channel.send(f"[{choice}]")

--- a/MoMMI/Modules/chance.py
+++ b/MoMMI/Modules/chance.py
@@ -95,3 +95,18 @@ Simple, just run @MoMMI magic 'Do I delete the Discord server?' and let NT's lat
     register_help(__name__, "pick", """Man can you believe this? People actually want to do *fair* 50/50 picks between things? Kids these days.
 
 Fine, just run @MoMMI pick(a,b,c) with as many comma separated values as you need. Normies.""")
+
+@command("giveissue", r"(?:giveissue)\s+(\w*)(?:\s+\((.*)\))?")
+async def giveissue_command(channel: MChannel, match: Match, message: Message) -> None:
+    repo = match.group(1).strip()
+    #text_params = [x.strip() for x in match.group(2).split(",")]
+    #r_params = re.compile(r"(\w*)=(\w*)")
+    #param_list = re.findAll(r_params, text_params)
+    #for param in param_list:
+        #add params
+    
+    url = github_url(f"/repos/{repo}/issuesidk")
+    commits = await get_github_object(url)
+
+    choice = random.choice(choices)
+    await channel.send(f"[{choice}]")

--- a/MoMMI/Modules/chance.py
+++ b/MoMMI/Modules/chance.py
@@ -96,17 +96,26 @@ Simple, just run @MoMMI magic 'Do I delete the Discord server?' and let NT's lat
 
 Fine, just run @MoMMI pick(a,b,c) with as many comma separated values as you need. Normies.""")
 
-@command("giveissue", r"(?:giveissue)\s+(\w*)(?:\s+\((.*)\))?")
+# todo
+# support short label codes like qol, bugfix etc, so not search for labels literally
+# filter for emojicracy, just use emoji-modifiers to calc total value of issue, then choose between top ~10ish
+@command("giveissue", r"(?:giveissue)(?:\s+([\w\,]*))?(?:\s+(\w\/))?")
 async def giveissue_command(channel: MChannel, match: Match, message: Message) -> None:
-    repo = match.group(1).strip()
-    #text_params = [x.strip() for x in match.group(2).split(",")]
-    #r_params = re.compile(r"(\w*)=(\w*)")
-    #param_list = re.findAll(r_params, text_params)
-    #for param in param_list:
-        #add params
-    
-    url = github_url(f"/repos/{repo}/issuesidk")
-    commits = await get_github_object(url)
+    channel.send(":hourglass_flowing_sand: Fetching random issue")
 
-    choice = random.choice(choices)
-    await channel.send(f"[{choice}]")
+    #getting labels
+    t_labels = [x.strip() for x in match.group(1).split(",")] # strip whitespaces
+    params = {"labels" : t_labels.join(",")}
+
+    #getting repo
+    repo = "vgstation-coders/vgstation13"
+    if(match.group(2))
+        repo = match.group(2).strip()
+
+    url = github_url(f"/repos/{repo}/issues", params)
+    issues = await get_github_object(url)
+
+    rand_issue = random.choice(issues)
+
+    await issue_command(channel, f"[{rand_issue}]", f"[{rand_issue}]")
+    #await channel.send(f"[{choice}]")

--- a/MoMMI/Modules/chance.py
+++ b/MoMMI/Modules/chance.py
@@ -99,6 +99,8 @@ Fine, just run @MoMMI pick(a,b,c) with as many comma separated values as you nee
 # todo
 # support short label codes like qol, bugfix etc, so not search for labels literally
 # filter for emojicracy, just use emoji-modifiers to calc total value of issue, then choose between top ~10ish
+# make it possible to harddefine params eg. repo = bla/bla, so you don't have to give a label to search other repos
+#   would also be nice to have when the emojicracy-filter gets to be a thing
 @command("giveissue", r"(?:giveissue)(?:\s+([\w\,]*))?(?:\s+(\w\/))?")
 async def giveissue_command(channel: MChannel, match: Match, message: Message) -> None:
     channel.send(":hourglass_flowing_sand: Fetching random issue")

--- a/MoMMI/Modules/chance.py
+++ b/MoMMI/Modules/chance.py
@@ -95,29 +95,3 @@ Simple, just run @MoMMI magic 'Do I delete the Discord server?' and let NT's lat
     register_help(__name__, "pick", """Man can you believe this? People actually want to do *fair* 50/50 picks between things? Kids these days.
 
 Fine, just run @MoMMI pick(a,b,c) with as many comma separated values as you need. Normies.""")
-
-# todo
-# support short label codes like qol, bugfix etc, so not search for labels literally
-# filter for emojicracy, just use emoji-modifiers to calc total value of issue, then choose between top ~10ish
-# make it possible to harddefine params eg. repo = bla/bla, so you don't have to give a label to search other repos
-#   would also be nice to have when the emojicracy-filter gets to be a thing
-@command("giveissue", r"(?:giveissue)(?:\s+([\w\,]*))?(?:\s+(\w\/))?")
-async def giveissue_command(channel: MChannel, match: Match, message: Message) -> None:
-    channel.send(":hourglass_flowing_sand: Fetching random issue")
-
-    #getting labels
-    t_labels = [x.strip() for x in match.group(1).split(",")] # strip whitespaces
-    params = {"labels" : t_labels.join(",")}
-
-    #getting repo
-    repo = "vgstation-coders/vgstation13"
-    if match.group(2)
-        repo = match.group(2).strip()
-
-    url = github_url(f"/repos/{repo}/issues", params)
-    issues = await get_github_object(url)
-
-    rand_issue = random.choice(issues).number
-
-    await issue_command(channel, f"[{rand_issue}]", f"[{rand_issue}]")
-    #await channel.send(f"[{choice}]")

--- a/MoMMI/Modules/chance.py
+++ b/MoMMI/Modules/chance.py
@@ -111,7 +111,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
 
     #getting repo
     repo = "vgstation-coders/vgstation13"
-    if(match.group(2))
+    if match.group(2)
         repo = match.group(2).strip()
 
     url = github_url(f"/repos/{repo}/issues", params)

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -818,7 +818,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
         part_issues = await get_github_object(url, {"labels" : labels, "page" : i, "per_page" : "100"})
         if part_issues:
             issues += part_issues
-            i++
+            i += 1
         else:
             break
 

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -804,7 +804,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
             await channel.send(":x: No random issue found")
             return
         
-        rand_issue = await random.choice(issue_page).number
+        rand_issue = await random.choice(issue_page)["number"]
 
         await post_embedded_issue(channel, repo, rand_issue)
 

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -785,6 +785,13 @@ async def jenkins_handicap_support(type: str, message: Any, meta: str) -> None:
 # dont use \w
 @command("giveissue", r"giveissue(?:\s+(\w+=\w+(?:,\w+=\w+)*))?")
 async def giveissue_command(channel: MChannel, match: Match, message: Message) -> None:
+    try:
+        cfg: List[Dict[str, Any]] = channel.server_config("modules.github.repos")
+    except:
+        # Server has no config settings for GitHub.
+        await channel.send(":trash: No config found")
+        return
+
     await channel.send(":hourglass_flowing_sand: Fetching random issue")
 
     #default params

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -46,7 +46,6 @@ KNOWN_MERGE_COMMITS: Set[str] = set()
 
 EVENT_MUTED_REPOS: Set[str] = set()
 
-
 def is_repo_muted(repo: str) -> bool:
     return repo in EVENT_MUTED_REPOS
 
@@ -830,8 +829,10 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
             else:
                 break
 
-
-        sort = sorted(issues, key=lambda i: get_github_object(f"{i.url}/reactions",{"content" : emote, "per_page" : "100"}).len)[ranking_limit:]
+        if emote:
+            sort = sorted(issues, key=lambda i: get_github_object(f"{i.url}/reactions",{"content" : emote, "per_page" : "100"}).len)[ranking_limit:]
+        else:
+            sort = issues
 
         rand_issue = await random.choice(sort).number
 

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -15,6 +15,7 @@ from MoMMI.commands import always_command
 from MoMMI.master import master
 from MoMMI.server import MServer
 from MoMMI.Modules.irc import irc_transform
+import random
 
 logger = logging.getLogger(__name__)
 
@@ -773,4 +774,28 @@ async def jenkins_handicap_support(type: str, message: Any, meta: str) -> None:
             async with session.post(post) as resp:
                 await resp.text()
 
+# todo
+# support short label codes like qol, bugfix etc, so not search for labels literally
+# filter for emojicracy, just use emoji-modifiers to calc total value of issue, then choose between top ~10ish
+# make it possible to harddefine params eg. repo = bla/bla, so you don't have to give a label to search other repos
+#   would also be nice to have when the emojicracy-filter gets to be a thing
+@command("giveissue", r"(?:giveissue)(?:\s+([\w\,]*))?(?:\s+(\w\/))?")
+async def giveissue_command(channel: MChannel, match: Match, message: Message) -> None:
+    await channel.send(":hourglass_flowing_sand: Fetching random issue")
 
+    #getting labels
+    t_labels = [x.strip() for x in match.group(1).split(",")] # strip whitespaces
+    params = {"labels" : t_labels.join(",")}
+
+    #getting repo
+    repo = "vgstation-coders/vgstation13"
+    if match.group(2)
+        repo = match.group(2).strip()
+
+    url = github_url(f"/repos/{repo}/issues", params)
+    issues = await get_github_object(url)
+
+    rand_issue = await random.choice(issues).number
+
+    await issue_command(channel, f"[{rand_issue}]", f"[{rand_issue}]")
+    #await channel.send(f"[{choice}]")

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -809,7 +809,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
             repo = temp[1].strip()
             continue
         if temp[0] == "labels":
-            labels = temp[1].strip().split("|").join(",")
+        	labels = temp[1].strip().split("|").join(",")
             continue
         if temp[0] == "emote":
             emote = re.search(REG_GIT_EMOTE, temp[1]).group(0)
@@ -819,11 +819,19 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
             continue
         await channel.send(f":trash: Warning: Unknown parameter: {temp[0]}")
 
-    url = github_url(f"/repos/{repo}/issues")
+    issues = []
+    i = 1
+    while(1)
+        url = github_url(f"/repos/{repo}/issues")
+        part_issues = await get_github_object(url, {"labels" : labels, "page" : i, "per_page" : "100"})
+        if part_issues:
+            issues += part_issues
+            i++
+        else:
+            break
 
-    issues = await get_github_object(url, {"labels" : labels})
 
-    sort = sorted(issues, key=lambda i: get_github_object(f"{i.url}/reactions?content={emote}").len)[ranking_limit:]
+    sort = sorted(issues, key=lambda i: get_github_object(f"{i.url}/reactions",{"content" : emote, "per_page" : "100"}).len)[ranking_limit:]
 
     rand_issue = await random.choice(sort).number
 

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -779,7 +779,7 @@ async def jenkins_handicap_support(type: str, message: Any, meta: str) -> None:
 # filter for emojicracy, just use emoji-modifiers to calc total value of issue, then choose between top ~10ish
 # make it possible to harddefine params eg. repo = bla/bla, so you don't have to give a label to search other repos
 #   would also be nice to have when the emojicracy-filter gets to be a thing
-@command("giveissue", r"(?:giveissue)(?:\s+([\w\,]*))?(?:\s+(\w\/))?")
+@command("giveissue", r"(?:giveissue)(?:\s+([\w\,]*))?(?:\s+([\w\/]*))?")
 async def giveissue_command(channel: MChannel, match: Match, message: Message) -> None:
     await channel.send(":hourglass_flowing_sand: Fetching random issue")
 

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -789,7 +789,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
 
     #getting repo
     repo = "vgstation-coders/vgstation13"
-    if match.group(2)
+    if match.group(2):
         repo = match.group(2).strip()
 
     url = github_url(f"/repos/{repo}/issues", params)

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -800,11 +800,11 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
         pagenum = random.randrange(1, maxpage)
 
         issue_page = await get_github_object(url, {"labels" : labels, "page" : pagenum, "per_page" : "100"})
-        rand_issue = await random.choice(issue_page).number
-
-        if(!rand_issue)
+        if len(issue_page) == 0:
             await channel.send(":x: No random issue found")
             return
+        
+        rand_issue = await random.choice(issue_page).number
 
         await post_embedded_issue(channel, repo, rand_issue)
 

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -812,9 +812,9 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
 
     issues = await get_github_object(url, {"labels" : labels})
 
-    sort = sorted(issues, key=lambda i: get_github_object(f"{i["url"]}/reactions?content={emote}").len)
+    sort = sorted(issues, key=lambda i: get_github_object(f"{i["url"]}/reactions?content={emote}").len)[20:]
 
-    rand_issue = await random.choice(issues).number
+    rand_issue = await random.choice(sort).number
 
     await issue_command(channel, f"[{rand_issue}]", f"[{rand_issue}]")
     #await channel.send(f"[{choice}]")

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -809,7 +809,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
             repo = temp[1].strip()
             continue
         if temp[0] == "labels":
-        	labels = temp[1].strip().split("|").join(",")
+            labels = temp[1].strip().split("|").join(",")
             continue
         if temp[0] == "emote":
             emote = re.search(REG_GIT_EMOTE, temp[1]).group(0)

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -798,16 +798,16 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
     
     for param in text_params:
         temp = param.split("=")
-        if(temp[0] == "repo")
+        if temp[0] == "repo":
             repo = temp[1].strip()
             continue
-        if(temp[0] == "labels")
+        if temp[0] == "labels":
             labels = temp[1].strip()
             continue
-        if(temp[0] == "emote")
+        if temp[0] == "emote":
             emote = re.search(REG_GIT_EMOTE, temp[1]).group(0)
             continue
-        if(temp[0] == "limit")
+        if temp[0] == "limit":
             ranking_limit = int(temp[1])
             continue
         await channel.send(f"Warning: Unknown parameter: {temp[0]}")
@@ -816,7 +816,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
 
     issues = await get_github_object(url, {"labels" : labels})
 
-    sort = sorted(issues, key=lambda i: get_github_object(f"{i["url"]}/reactions?content={emote}").len)[ranking_limit:]
+    sort = sorted(issues, key=lambda i: get_github_object(f"{i.url}/reactions?content={emote}").len)[ranking_limit:]
 
     rand_issue = await random.choice(sort).number
 

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -760,33 +760,31 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
     
     for param in text_params:
         temp = param.split("=")
-        switch(temp[0]) {
-            case "prefix":
-                prefix = temp[1].strip()
+        if temp[0] == "prefix":
+            prefix = temp[1].strip()
+            continue
+        if temp[0] == "labels":
+            autolabels: Dict[str, str] = master.config.get_module(
+                f"github.repos.{repo_name}.autolabels", {})
+            if not autolabels:
+                await channel.send(":x: Could not find autolabel config, skipping labels param")
                 continue
-            case "labels":
-                autolabels: Dict[str, str] = master.config.get_module(
-                    f"github.repos.{repo_name}.autolabels", {})
-                if not autolabels:
-                    await channel.send(":x: Could not find autolabel config, skipping labels param")
-                    continue
 
-                to_add = set()
-                param_labels = temp[1].strip().split(",")
-                for p_label in param_labels:
-                    matched_label = autolabels.get(p_label.lower())
-                    if matched_label:
-                        to_add.add(matched_label)
+            to_add = set()
+            param_labels = temp[1].strip().split(",")
+            for p_label in param_labels:
+                matched_label = autolabels.get(p_label.lower())
+                if matched_label:
+                    to_add.add(matched_label)
 
-                labels = ",".join(to_add)
-                continue
-            case "limit":
-                ranking_limit = int(temp[1])
-                continue
-            default:
-                await channel.send(f":trash: Warning: Unknown parameter: {temp[0]}")
-            break;
-        }
+            labels = ",".join(to_add)
+            continue
+        if temp[0] == "limit":
+            ranking_limit = int(temp[1])
+            continue
+
+        await channel.send(f":trash: Warning: Unknown parameter: {temp[0]}")
+
         
 
     for repo_config in cfg:

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -777,6 +777,8 @@ async def jenkins_handicap_support(type: str, message: Any, meta: str) -> None:
 # todo
 # support short label codes like qol, bugfix etc, so not search for labels literally
 # filter for emojicracy, just use emoji-modifiers to calc total value of issue, then choose between top ~10ish
+#   /repos/:owner/:repo/issues/:issue_number/reactions?content=+1 (or hooray, heart, confused, laugh, -1)
+#   needs Accept: application/json in header
 # make it possible to harddefine params eg. repo = bla/bla, so you don't have to give a label to search other repos
 #   would also be nice to have when the emojicracy-filter gets to be a thing
 @command("giveissue", r"(?:giveissue)(?:\s+([\w\,]*))?(?:\s+([\w\/]*))?")

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -760,16 +760,34 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
     
     for param in text_params:
         temp = param.split("=")
-        if temp[0] == "prefix":
-            prefix = temp[1].strip()
-            continue
-        if temp[0] == "labels":
-            labels = temp[1].strip()
-            continue
-        if temp[0] == "limit":
-            ranking_limit = int(temp[1])
-            continue
-        await channel.send(f":trash: Warning: Unknown parameter: {temp[0]}")
+        switch(temp[0]) {
+            case "prefix":
+                prefix = temp[1].strip()
+                continue
+            case "labels":
+                autolabels: Dict[str, str] = master.config.get_module(
+                    f"github.repos.{repo_name}.autolabels", {})
+                if not autolabels:
+                    await channel.send(":x: Could not find autolabel config, skipping labels param")
+                    continue
+
+                to_add = set()
+                param_labels = temp[1].strip().split(",")
+                for p_label in param_labels:
+                    matched_label = autolabels.get(p_label.lower())
+                    if matched_label:
+                        to_add.add(matched_label)
+
+                labels = ",".join(to_add)
+                continue
+            case "limit":
+                ranking_limit = int(temp[1])
+                continue
+            default:
+                await channel.send(f":trash: Warning: Unknown parameter: {temp[0]}")
+            break;
+        }
+        
 
     for repo_config in cfg:
         repo = repo_config["repo"]

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -792,8 +792,8 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
     if match.group(2):
         repo = match.group(2).strip()
 
-    url = github_url(f"/repos/{repo}/issues", params)
-    issues = await get_github_object(url)
+    url = github_url(f"/repos/{repo}/issues")
+    issues = await get_github_object(url, params)
 
     rand_issue = await random.choice(issues).number
 

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -791,6 +791,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
     repo = "vgstation-coders/vgstation13"
     labels = ""
     emote = "+1"
+    ranking_limit = 20
 
     #getting params
     text_params = [x.strip() for x in match.group(1).split(",")] # strip whitespaces
@@ -806,13 +807,16 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
         if(temp[0] == "emote")
             emote = re.search(REG_GIT_EMOTE, temp[1]).group(0)
             continue
+        if(temp[0] == "limit")
+            ranking_limit = int(temp[1])
+            continue
         await channel.send(f"Warning: Unknown parameter: {temp[0]}")
 
     url = github_url(f"/repos/{repo}/issues")
 
     issues = await get_github_object(url, {"labels" : labels})
 
-    sort = sorted(issues, key=lambda i: get_github_object(f"{i["url"]}/reactions?content={emote}").len)[20:]
+    sort = sorted(issues, key=lambda i: get_github_object(f"{i["url"]}/reactions?content={emote}").len)[ranking_limit:]
 
     rand_issue = await random.choice(sort).number
 

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -810,7 +810,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
         if temp[0] == "limit":
             ranking_limit = int(temp[1])
             continue
-        await channel.send(f"Warning: Unknown parameter: {temp[0]}")
+        await channel.send(f":trash: Warning: Unknown parameter: {temp[0]}")
 
     url = github_url(f"/repos/{repo}/issues")
 
@@ -821,4 +821,3 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
     rand_issue = await random.choice(sort).number
 
     await issue_command(channel, f"[{rand_issue}]", f"[{rand_issue}]")
-    #await channel.send(f"[{choice}]")

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -775,7 +775,7 @@ async def jenkins_handicap_support(type: str, message: Any, meta: str) -> None:
 # make it possible to harddefine params eg. repo = bla/bla, so you don't have to give a label to search other repos
 #   would also be nice to have when the emojicracy-filter gets to be a thing
 # dont use \w
-@command("giveissue", r"giveissue(?:\s+(\w+=\w+(?:,\w+=\w+)*))?")
+@command("giveissue", r"giveissue(?:\s+(-\w+=\w+(?:\s+-\w+=\w+)*))?")
 async def giveissue_command(channel: MChannel, match: Match, message: Message) -> None:
     try:
         cfg: List[Dict[str, Any]] = channel.server_config("modules.github.repos")
@@ -793,7 +793,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
     ranking_limit = 20
 
     #getting params
-    text_params = [x.strip() for x in match.group(1).split(",")] # strip whitespaces
+    text_params = [x.strip() for x in match.group(1).split(" -")] # strip whitespaces
     
     for param in text_params:
         temp = param.split("=")
@@ -801,7 +801,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
             repo = temp[1].strip()
             continue
         if temp[0] == "labels":
-            labels = temp[1].strip().split("|").join(",")
+            labels = temp[1].strip()
             continue
         if temp[0] == "emote":
             emote = re.search(REG_GIT_EMOTE, temp[1]).group(0)

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -821,7 +821,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
 
     issues = []
     i = 1
-    while(1)
+    while 1:
         url = github_url(f"/repos/{repo}/issues")
         part_issues = await get_github_object(url, {"labels" : labels, "page" : i, "per_page" : "100"})
         if part_issues:

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -856,17 +856,3 @@ async def post_embedded_issue(channel: Channel, repo, issueid):
     embed.description += "\n\u200B"
 
     await channel.send(embed=embed)
-
-def parse_link_header(header) -> Any:
-    links = header.split(",")
-    result = {}
-    for link in links:
-        link = link.strip()
-        elements = link.split(";")
-
-        pagenum = re.search(REG_GIT_PAGE, elements[0]).group(1)
-        index = re.search(REG_GIT_REL, elements[1]).group(1)
-        
-        result[index] = pagenum
-
-    return result

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -809,7 +809,7 @@ async def giveissue_command(channel: MChannel, match: Match, message: Message) -
             repo = temp[1].strip()
             continue
         if temp[0] == "labels":
-            labels = temp[1].strip()
+            labels = temp[1].strip().split("|").join(",")
             continue
         if temp[0] == "emote":
             emote = re.search(REG_GIT_EMOTE, temp[1]).group(0)


### PR DESCRIPTION
gives peeps a random issue to work on, default repo is /vg/'s, but can be otherwise defined.

Command syntax is `@MoMMiv2 giveissue -param=paramvalue`
all params are optional, so you can also just go `@MoMMiv2 giveissue`

Available params to set:
- labels
- emote (+1 | -1 | laugh | confused | heart | hooray)
- limit 20 (how many issues with the fitting emote to choose from)
- prefix

~I plan to add support for shortend labeltags, since right now you'd have to type out shit like `❤️ Quality of Life ❤️`, then hope the emojis dont get fucked with, instead of just typing qol.~

Also closes #8