### PR TITLE
Remove HTML-Comments

### DIFF
--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -143,7 +143,7 @@ async def on_github_push(channel: MChannel, message: Any, meta: str) -> None:
     if not found:
         return
 
-    embed.description = content
+    embed.description = format_desc(content)
 
     await channel.send(embed=embed)
 
@@ -174,6 +174,8 @@ async def on_github_issues(channel: MChannel, message: Any, meta: str) -> None:
         embed.description = issue["body"][:MAX_BODY_LENGTH] + "..."
     else:
         embed.description = issue["body"]
+
+    embed.description = format_desc(embed.description)    
 
     embed.description += "\n\u200B"
 
@@ -218,6 +220,9 @@ async def on_github_pull_request(channel: MChannel, message: Any, meta: str) -> 
         embed.description = new_body[:MAX_BODY_LENGTH] + "..."
     else:
         embed.description = new_body
+
+    embed.description = format_desc(embed.description)
+
     embed.description += "\n\u200B"
 
     if is_repo_muted(repository["full_name"]):
@@ -256,6 +261,8 @@ async def on_github_issue_comment(channel: MChannel, message: Any, meta: str) ->
         embed.description = comment["body"][:MAX_BODY_LENGTH] + "..."
     else:
         embed.description = comment["body"]
+
+    embed.description = format_desc(embed.description)
 
     await channel.send(embed=embed)
 
@@ -431,6 +438,9 @@ async def issue_command(channel: MChannel, match: Match, message: Message) -> No
                 embed.description = content["body"][:MAX_BODY_LENGTH] + "..."
             else:
                 embed.description = content["body"]
+
+            embed.description = format_desc(embed.description)
+
             embed.description += "\n\u200B"
 
             await channel.send(embed=embed)
@@ -463,7 +473,7 @@ async def issue_command(channel: MChannel, match: Match, message: Message) -> No
                 text=f"{repo} {sha} by {commit['author']['name']}")
             embed.url = commit["html_url"]
             embed.title = title
-            embed.description = desc
+            embed.description = format_desc(desc)
 
             await channel.send(embed=embed)
 
@@ -773,4 +783,6 @@ async def jenkins_handicap_support(type: str, message: Any, meta: str) -> None:
             async with session.post(post) as resp:
                 await resp.text()
 
-
+def format_desc(desc: str) -> str:
+    var res = re.subn(MD_COMMENT_RE, "", desc)
+    return res[0]

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -143,7 +143,7 @@ async def on_github_push(channel: MChannel, message: Any, meta: str) -> None:
     if not found:
         return
 
-    embed.description = format_desc(content)
+    embed.description = content
 
     await channel.send(embed=embed)
 
@@ -170,12 +170,8 @@ async def on_github_issues(channel: MChannel, message: Any, meta: str) -> None:
         name=sender["login"], url=sender["html_url"], icon_url=sender["avatar_url"])
     embed.set_footer(text="{}#{} by {}".format(
         repository["full_name"], issue["number"], issue["user"]["login"]), icon_url=issue["user"]["avatar_url"])
-    if len(issue["body"]) > MAX_BODY_LENGTH:
-        embed.description = issue["body"][:MAX_BODY_LENGTH] + "..."
-    else:
-        embed.description = issue["body"]
 
-    embed.description = format_desc(embed.description)    
+    embed.description = format_desc(issue["body"])    
 
     embed.description += "\n\u200B"
 
@@ -215,13 +211,7 @@ async def on_github_pull_request(channel: MChannel, message: Any, meta: str) -> 
     embed.set_footer(text="{}#{} by {}".format(
         repository["full_name"], pull_request["number"], pull_request["user"]["login"]), icon_url=pull_request["user"]["avatar_url"])
 
-    new_body = MD_COMMENT_RE.sub("", pull_request["body"])
-    if len(new_body) > MAX_BODY_LENGTH:
-        embed.description = new_body[:MAX_BODY_LENGTH] + "..."
-    else:
-        embed.description = new_body
-
-    embed.description = format_desc(embed.description)
+    embed.description = format_desc(pull_request["body"])
 
     embed.description += "\n\u200B"
 
@@ -257,12 +247,8 @@ async def on_github_issue_comment(channel: MChannel, message: Any, meta: str) ->
         text=f"{repo_name}#{issue['number']} by {issue['user']['login']}")
     embed.title = f"New Comment: {issue['title']}"
     embed.url = message["comment"]["html_url"]
-    if len(comment["body"]) > MAX_BODY_LENGTH:
-        embed.description = comment["body"][:MAX_BODY_LENGTH] + "..."
-    else:
-        embed.description = comment["body"]
 
-    embed.description = format_desc(embed.description)
+    embed.description = format_desc(comment["body"])
 
     await channel.send(embed=embed)
 
@@ -434,12 +420,8 @@ async def issue_command(channel: MChannel, match: Match, message: Message) -> No
             embed.url = content["html_url"]
             embed.set_footer(
                 text=f"{repo}#{content['number']} by {content['user']['login']}", icon_url=content["user"]["avatar_url"])
-            if len(content["body"]) > MAX_BODY_LENGTH:
-                embed.description = content["body"][:MAX_BODY_LENGTH] + "..."
-            else:
-                embed.description = content["body"]
 
-            embed.description = format_desc(embed.description)
+            embed.description = format_desc(content["body"])
 
             embed.description += "\n\u200B"
 
@@ -784,5 +766,8 @@ async def jenkins_handicap_support(type: str, message: Any, meta: str) -> None:
                 await resp.text()
 
 def format_desc(desc: str) -> str:
-    res = re.subn(MD_COMMENT_RE, "", desc)
+    res = re.subn(MD_COMMENT_RE, "", desc) # we need to use subn so it actually gets all the comments, not just the first
+
+    if len(res) > MAX_BODY_LENGTH:
+        res = res[:MAX_BODY_LENGTH] + "..."
     return res[0]

--- a/MoMMI/Modules/github.py
+++ b/MoMMI/Modules/github.py
@@ -784,5 +784,5 @@ async def jenkins_handicap_support(type: str, message: Any, meta: str) -> None:
                 await resp.text()
 
 def format_desc(desc: str) -> str:
-    var res = re.subn(MD_COMMENT_RE, "", desc)
+    res = re.subn(MD_COMMENT_RE, "", desc)
     return res[0]


### PR DESCRIPTION
HTML Comments are irrelevant in embedded Issues and PR and basically just push out the actual content when someone forgets to remove them.

This adds format_desc, which is called on every embedded github description, so you can add formatting later on if needed.

I also noticed you already did this in one function, but you used `sub`, which - if i read the docs correctly - only removes the first instance. hence i am using `subn`

I too moved shortening into format_desc