### PR TITLE
Change Discord #ick lock to five minutes

### DIFF
--- a/MoMMI/Modules/gamenudge.py
+++ b/MoMMI/Modules/gamenudge.py
@@ -125,13 +125,13 @@ def utcnow() -> datetime:
 
 
 async def thread_reminder(channel: MChannel) -> None:
-    minutes = 8
+    minutes = 5
     # Send the message
     await channel.send(f"**A round has ended.** You can discuss it at https://boards.4chan.org/vg/catalog#s=ss13g. This channel will be closed for {minutes} minutes.")
     # And make it closed
     await channel.close()
     # For 5 minutes
-    await asyncio.sleep(8 * 60)
+    await asyncio.sleep(5 * 60)
     # And open it
     await channel.open()
     await channel.send("**This channel is open for discussion again.**")


### PR DESCRIPTION
> Bomber Harris — Today at 1:05 PM
> @Dilt if you want to make the lock 5 minutes go for it
> I’d like to see the effects

This will make the Discord lock last only five minutes. Bomber would like to see the effects.